### PR TITLE
:tada: My first commit :tada:

### DIFF
--- a/src/containers/Nav/Nav.tsx
+++ b/src/containers/Nav/Nav.tsx
@@ -1,14 +1,21 @@
 import Toolbar from '@material-ui/core/Toolbar'
 import React from 'react'
+import { useIsDesktop } from '../../styles'
 import * as S from './Nav.styles'
 import { NavItems } from './NavItems'
+import { NotificationBar } from './NavNotificationBar'
 
 export function Nav() {
+  const isDesktop = useIsDesktop()
+
   return (
     <S.Grow>
       <S.AppBar
         position="static"
       >
+        {
+          isDesktop && <NotificationBar />
+        }
         <Toolbar>
           <NavItems />
         </Toolbar>

--- a/src/containers/Nav/NavNotificationBar.styles.ts
+++ b/src/containers/Nav/NavNotificationBar.styles.ts
@@ -1,0 +1,31 @@
+import ToolbarMUI from '@material-ui/core/Toolbar'
+import styled from 'styled-components'
+import { Button } from 'src/components/Button'
+import { theme, colors } from 'src/styles'
+
+// TODO: Remove the ampersand (&) character in styled-components after removing of ThemeProvider of MUI.
+// Goal: Prioritize the CSS rules of your styled-components over those of the JSS.
+// See: https://www.sipios.com/blog-tech/how-to-use-styled-components-with-material-ui-in-a-react-app
+
+export const NotificationBar = styled(ToolbarMUI)`
+  && {
+    background-color: ${colors.main.primary};
+    color: ${colors.main.white};
+  }
+`
+
+export const NotificationItem = styled.div`
+  margin-left: ${theme.spacing(2)}px;
+  display: flex;
+  align-items: center;
+`
+
+export const WhiteOutlinedButton = styled(Button).attrs(() => ({
+  variant: 'outlined',
+}))`
+ && {
+   color: ${colors.main.white};
+   border-color: ${colors.main.white};
+   text-transform: none !important;
+ }
+`

--- a/src/containers/Nav/NavNotificationBar.tsx
+++ b/src/containers/Nav/NavNotificationBar.tsx
@@ -1,0 +1,42 @@
+import { Typography } from '@material-ui/core'
+import { History } from '@material-ui/icons'
+import React from 'react'
+import { texts } from '../../i18n'
+import * as Nav from './Nav.styles'
+import * as S from './NavNotificationBar.styles'
+
+export function NotificationBar() {
+  return (
+    <S.NotificationBar variant="dense">
+      <S.NotificationItem>
+        <Typography
+          color="textSecondary"
+          variant="body1"
+        >
+          {texts.nav.notificationBar.welcome}
+        </Typography>
+      </S.NotificationItem>
+      <S.NotificationItem>
+        <S.WhiteOutlinedButton
+          onClick={() => {
+            // Send false error to be caught by Sentry so we can open the feedback dialog
+            if (process.env.NODE_ENV !== 'development') {
+              throw new Error('user-feedback')
+            }
+          }}
+          size="small"
+        >
+          {texts.nav.notificationBar.feedback}
+        </S.WhiteOutlinedButton>
+      </S.NotificationItem>
+
+      <Nav.Grow />
+      <Nav.NavItem
+        color="textSecondary"
+        href="https://entourage.social/app"
+        icon={<History fontSize="small" />}
+        label={texts.nav.notificationBar.back}
+      />
+    </S.NotificationBar>
+  )
+}

--- a/src/core/sentry/index.ts
+++ b/src/core/sentry/index.ts
@@ -1,9 +1,28 @@
 import * as Sentry from '@sentry/browser'
+import { texts } from '../../i18n'
 import { env } from 'src/core/env'
 
 export function initSentry() {
   if (process.env.NODE_ENV === 'development') return
   Sentry.init({
     dsn: env.SENTRY_DSN,
+    beforeSend(event) {
+      if (
+        !!(event?.exception?.values)
+        && event.exception.values.length > 0
+        && event.exception.values.some(((error) => error.value === 'user-feedback'))
+      ) {
+        Sentry.showReportDialog({
+          eventId: event.event_id,
+          lang: texts.nav.notificationBar.dialogLang,
+          title: texts.nav.notificationBar.dialogTitle,
+          subtitle: texts.nav.notificationBar.dialogSubtitle,
+          subtitle2: texts.nav.notificationBar.dialogSubtitle2,
+          labelComments: texts.nav.notificationBar.dialogLabelComments,
+          labelSubmit: texts.nav.notificationBar.dialogLabelSubmit,
+        })
+      }
+      return event
+    },
   })
 }

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -17,6 +17,18 @@ export const texts = {
     INCORRECT_VALUE: 'Valeur incorrecte',
   },
   nav: {
+    notificationBar: {
+      welcome: 'Bienvenue sur la nouvelle version de l\'application Entourage !',
+      feedback: 'Donnez-nous votre avis !',
+      back: 'Revenir sur l\'ancienne version',
+      dialogLang: 'fr',
+      dialogTitle: 'Votre avis nous intéresse !',
+      dialogSubtitle: 'Nous sommes toujours à l\'écoute de vos remarques.',
+      dialogSubtitle2: 'Si vous identifiez des bugs ou voulez juste nous partager vos suggestions, n\'hésitez pas à remplir le formulaire !',
+      dialogLabelComments: 'Vos remarques et suggestions',
+      dialogLabelSubmit: 'Envoyer',
+
+    },
     actions: 'Actions',
     messages: 'Messages',
     takeAction: 'Passer à l\'action',

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -99,6 +99,17 @@ export default class App extends NextApp<{ authUserData: LoggedUser; }> {
     return (
       <>
         <Head>
+          <script
+            {/* eslint-disable-next-line react/no-danger */}
+            dangerouslySetInnerHTML={{
+              // Force HTTPS redirection on client side because can't do it with Heroku nor Gandi
+              __html: `
+                if (window.location.protocol !== 'https:' && ${process.env.NODE_ENV !== 'development'}) {
+                  window.location.replace(\`https:\${window.location.href.substring(window.location.protocol.length)}\`)
+                }
+              `,
+            }}
+          />
           <title>Home</title>
           <link href="/favicon.ico" rel="icon" />
           <base href="/" />


### PR DESCRIPTION
[EN-3435] Banner with user feedback form and link to v1
To be able to show the feedback dialog from Sentry, there has to be an error to catch (it doesn't work to just call `Sentry.showDialog()` from the component, there's a 400 error on the API call). I simulated an error, only in production, to show the dialog when we catch this fake error.
[EN-3437] Client side http -> https redirection
I used `dangerouslySetInnerHTML` because if i put in in the `componentDidMount` of the __app.tsx_, the whole page was loaded before doing the redirection, which is a bit confusing for the user. The way I did it, the user doesn't even have time to see the redirection.

[EN-3435]: https://entourage-asso.atlassian.net/browse/EN-3435
[EN-3437]: https://entourage-asso.atlassian.net/browse/EN-3437