### PR TITLE
Fix Google Maps 'places_impl' loading error and upgrade UUID warning

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,15 +7,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
       with:
         node-version: 14.x
         check-latest: true
 
-    - run: echo "::set-output name=dir::$(yarn cache dir)"
+    - run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       id: yarn-cache-dir-path
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       with:
         path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
         key: yarn-${{ hashFiles('**/yarn.lock') }}

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@date-io/date-fns": "^1.3.13",
+    "@googlemaps/js-api-loader": "^2.0.2",
     "@material-ui/core": "^4.12.3",
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "4.0.0-alpha.39",
@@ -119,5 +120,8 @@
     "react-test-renderer": "^16.11.0",
     "ts-loader": "^6.2.1",
     "typescript": "~4.6.4"
+  },
+  "resolutions": {
+    "uuid": "^8.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@date-io/date-fns": "^1.3.13",
-    "@googlemaps/js-api-loader": "^2.0.2",
+    "@googlemaps/js-api-loader": "^1.16.8",
     "@material-ui/core": "^4.12.3",
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "4.0.0-alpha.39",

--- a/src/containers/MapContainer/LeftLists/SearchCity.tsx
+++ b/src/containers/MapContainer/LeftLists/SearchCity.tsx
@@ -28,8 +28,8 @@ export function SearchCity(props: SearchCityProps) {
 
     const placeDetail = await getDetailPlacesService(value.place.place_id, value.sessionToken)
 
-    const lat = placeDetail.geometry?.location.lat()
-    const lng = placeDetail.geometry?.location.lng()
+    const lat = placeDetail.geometry?.location?.lat()
+    const lng = placeDetail.geometry?.location?.lng()
     const address = placeDetail.formatted_address
 
     assertIsNumber(lat)

--- a/src/core/useCases/messages/__mocks__.ts
+++ b/src/core/useCases/messages/__mocks__.ts
@@ -35,10 +35,12 @@ export const fakeMessagesData: MessagesState = {
     abc: {
       ...createConversationItem(),
       uuid: 'abc',
+      updatedAt: '2026-03-09T15:34:50.322Z',
     },
     def: {
       ...createConversationItem(),
       uuid: 'def',
+      updatedAt: '2026-03-09T15:34:50.321Z',
     },
   },
   selectedConversationUuid: null,

--- a/src/utils/misc/GoogleMaps.ts
+++ b/src/utils/misc/GoogleMaps.ts
@@ -1,12 +1,21 @@
-import { useMemo, useCallback } from 'react'
+import { setOptions, importLibrary } from '@googlemaps/js-api-loader'
+import { useMemo, useCallback, useState, useEffect } from 'react'
 import { GoogleMapLocationValue } from 'src/components/GoogleMapLocation'
 import { env } from 'src/core/env'
 import { useStateGetter } from 'src/utils/hooks'
-import { assertIsDefined, assertIsNumber, assertIsString, isSSR, useScript, useScriptIsReady } from 'src/utils/misc'
 
-const scriptUrl = `https://maps.googleapis.com/maps/api/js?key=${env.GOOGLE_MAP_API_KEY}&libraries=places`
+import { assertIsDefined, assertIsNumber, assertIsString, isSSR } from 'src/utils/misc'
 
 const googleMapsUrl = 'https://www.google.com/maps/search/?api=1&query='
+
+if (typeof window !== 'undefined') {
+  setOptions({
+    key: env.GOOGLE_MAP_API_KEY,
+    v: 'weekly',
+  })
+}
+
+let apiStatus: 'idle' | 'loading' | 'ready' | 'error' = 'idle'
 
 class GoogleMapApiNotLoaded extends Error {
   name = 'Google Map Api is not loaded'
@@ -25,7 +34,7 @@ export function getDetailPlacesService(
   return new Promise((resolve) => {
     new google.maps.places.PlacesService(document.createElement('div'))
       .getDetails(requestGetDetail, (res) => {
-        resolve(res)
+        resolve(res as google.maps.places.PlaceResult)
       })
   })
 }
@@ -38,8 +47,8 @@ export async function getLocationFromPlace(autocompletePlace: GoogleMapLocationV
     autocompletePlace.sessionToken,
   )
 
-  const latitude = placeDetail.geometry?.location.lat()
-  const longitude = placeDetail.geometry?.location.lng()
+  const latitude = placeDetail.geometry?.location?.lat()
+  const longitude = placeDetail.geometry?.location?.lng()
   const googlePlaceId = autocompletePlace.place.place_id
   const streetAddress = placeDetail.formatted_address
   const placeName = placeDetail.name
@@ -69,17 +78,41 @@ export function getDetailPlacesFromCoordinatesService(
   return new Promise((resolve) => {
     new google.maps.Geocoder()
       .geocode(requestGetDetail, (res) => {
-        resolve(res)
+        resolve(res as google.maps.GeocoderResult[])
       })
   })
 }
 
 export function useLoadGoogleMapApi() {
-  const url = !isSSR
-    ? scriptUrl
-    : ''
+  const [status, setStatus] = useState(apiStatus)
 
-  const status = useScript(url)
+  useEffect(() => {
+    if (isSSR || apiStatus === 'ready' || apiStatus === 'error') {
+      return
+    }
+
+    if (apiStatus === 'idle') {
+      apiStatus = 'loading'
+      setStatus('loading')
+
+      importLibrary('places')
+        .then(() => {
+          apiStatus = 'ready'
+          setStatus('ready')
+        })
+        .catch(() => {
+          apiStatus = 'error'
+          setStatus('error')
+        })
+    } else {
+      // apiStatus is 'loading', we need to wait for it.
+      // JS API Loader's `load()` function handles multiple calls gracefully
+      // by returning the same promise.
+      importLibrary('places')
+        .then(() => setStatus('ready'))
+        .catch(() => setStatus('error'))
+    }
+  }, [])
 
   if (status === 'idle' || status === 'loading') {
     return false
@@ -93,7 +126,7 @@ export function useLoadGoogleMapApi() {
 }
 
 export function useAutocompleteSessionToken() {
-  if (!useScriptIsReady(scriptUrl)) {
+  if (apiStatus !== 'ready') {
     throw new GoogleMapApiNotLoaded()
   }
 
@@ -112,7 +145,7 @@ export function useAutocompleteSessionToken() {
 }
 
 export function useAutocompleteServices() {
-  if (!useScriptIsReady(scriptUrl)) {
+  if (apiStatus !== 'ready') {
     throw new GoogleMapApiNotLoaded()
   }
 

--- a/src/utils/misc/GoogleMaps.ts
+++ b/src/utils/misc/GoogleMaps.ts
@@ -1,4 +1,4 @@
-import { setOptions, importLibrary } from '@googlemaps/js-api-loader'
+import { Loader } from '@googlemaps/js-api-loader'
 import { useMemo, useCallback, useState, useEffect } from 'react'
 import { GoogleMapLocationValue } from 'src/components/GoogleMapLocation'
 import { env } from 'src/core/env'
@@ -8,12 +8,11 @@ import { assertIsDefined, assertIsNumber, assertIsString, isSSR } from 'src/util
 
 const googleMapsUrl = 'https://www.google.com/maps/search/?api=1&query='
 
-if (typeof window !== 'undefined') {
-  setOptions({
-    key: env.GOOGLE_MAP_API_KEY,
-    v: 'weekly',
-  })
-}
+const loader = typeof window !== 'undefined' ? new Loader({
+  apiKey: env.GOOGLE_MAP_API_KEY,
+  version: 'weekly',
+  libraries: ['places'],
+}) : null
 
 let apiStatus: 'idle' | 'loading' | 'ready' | 'error' = 'idle'
 
@@ -95,7 +94,8 @@ export function useLoadGoogleMapApi() {
       apiStatus = 'loading'
       setStatus('loading')
 
-      importLibrary('places')
+      const promise = (loader as Loader).load()
+      promise
         .then(() => {
           apiStatus = 'ready'
           setStatus('ready')
@@ -108,7 +108,8 @@ export function useLoadGoogleMapApi() {
       // apiStatus is 'loading', we need to wait for it.
       // JS API Loader's `load()` function handles multiple calls gracefully
       // by returning the same promise.
-      importLibrary('places')
+      const promise = (loader as Loader).load()
+      promise
         .then(() => setStatus('ready'))
         .catch(() => setStatus('error'))
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2339,12 +2339,10 @@
     performance-now "^2.1.0"
     raf "^3.4.1"
 
-"@googlemaps/js-api-loader@^2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@googlemaps/js-api-loader/-/js-api-loader-2.0.2.tgz#09d8b2029e71bfeb3951747b1ca951e5f8fcb14f"
-  integrity sha512-bKVuTqatS8Jven5aFqVB7rCHF1VFEzpzyi0ruzO0GUR+A7m9oMqMgtnmpANj7kMYEvvhty8Fk7TnJ1MKjWHu+Q==
-  dependencies:
-    "@types/google.maps" "^3.53.1"
+"@googlemaps/js-api-loader@^1.16.8":
+  version "1.16.10"
+  resolved "https://registry.yarnpkg.com/@googlemaps/js-api-loader/-/js-api-loader-1.16.10.tgz#b61cf2b4a1b6ed77017b0dab131e6d51e814ec4e"
+  integrity sha512-c2erv2k7P2ilYzMmtYcMgAR21AULosQuUHJbStnrvRk2dG93k5cqptDrh9A8p+ZNlyhiqEOgHW7N9PAizdUM7Q==
 
 "@hapi/accept@5.0.2":
   version "5.0.2"
@@ -4011,11 +4009,6 @@
   integrity sha512-2qF4l8alBNqs0fJOqubhuOpWFHAFOgq2uLfypXRq/5WmbaLeVPvH0d8WIObr7EfUFPBJHeQONB0QVwlfVeOJRw==
   dependencies:
     "@types/react" "*"
-
-"@types/google.maps@^3.53.1":
-  version "3.58.1"
-  resolved "https://registry.yarnpkg.com/@types/google.maps/-/google.maps-3.58.1.tgz#71ce3dec44de1452f56641d2c87c7dd8ea964b4d"
-  integrity sha512-X9QTSvGJ0nCfMzYOnaVs/k6/4L+7F5uCS+4iUmkLEls6J9S/Phv+m/i3mDeyc49ZBgwab3EFO1HEoBY7k98EGQ==
 
 "@types/googlemaps@^3.40.4":
   version "3.40.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2339,6 +2339,13 @@
     performance-now "^2.1.0"
     raf "^3.4.1"
 
+"@googlemaps/js-api-loader@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@googlemaps/js-api-loader/-/js-api-loader-2.0.2.tgz#09d8b2029e71bfeb3951747b1ca951e5f8fcb14f"
+  integrity sha512-bKVuTqatS8Jven5aFqVB7rCHF1VFEzpzyi0ruzO0GUR+A7m9oMqMgtnmpANj7kMYEvvhty8Fk7TnJ1MKjWHu+Q==
+  dependencies:
+    "@types/google.maps" "^3.53.1"
+
 "@hapi/accept@5.0.2":
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/@hapi/accept/-/accept-5.0.2.tgz#ab7043b037e68b722f93f376afb05e85c0699523"
@@ -4004,6 +4011,11 @@
   integrity sha512-2qF4l8alBNqs0fJOqubhuOpWFHAFOgq2uLfypXRq/5WmbaLeVPvH0d8WIObr7EfUFPBJHeQONB0QVwlfVeOJRw==
   dependencies:
     "@types/react" "*"
+
+"@types/google.maps@^3.53.1":
+  version "3.58.1"
+  resolved "https://registry.yarnpkg.com/@types/google.maps/-/google.maps-3.58.1.tgz#71ce3dec44de1452f56641d2c87c7dd8ea964b4d"
+  integrity sha512-X9QTSvGJ0nCfMzYOnaVs/k6/4L+7F5uCS+4iUmkLEls6J9S/Phv+m/i3mDeyc49ZBgwab3EFO1HEoBY7k98EGQ==
 
 "@types/googlemaps@^3.40.4":
   version "3.40.4"
@@ -16886,17 +16898,7 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
-uuid@^3.1.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
-  integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
-
-uuid@^3.3.2:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
-  integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==
-
-uuid@^8.3.0:
+uuid@^3.1.0, uuid@^3.3.2, uuid@^8.3.0:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.0.tgz#ab738085ca22dc9a8c92725e459b1d507df5d6ea"
   integrity sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==


### PR DESCRIPTION
Fixes the critical Google Maps loading failure by implementing the modern API Loader library, resolves the `uuid` version deprecation warning, and ensures all TypeScript / Jest CI checks pass cleanly.

---
*PR created automatically by Jules for task [590271253941114342](https://jules.google.com/task/590271253941114342) started by @FrPellissier*